### PR TITLE
Fix to specify PyJWT version

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ django-cors-headers
 django-debug-toolbar
 django-environ
 django-filter
+PyJWT==2.1.0
 djangorestframework
 djangorestframework-simplejwt
 djoser


### PR DESCRIPTION
Version 2.2.0 is currently malfunction due to decoding method error