### PR TITLE
Fix not to redirect to gunicorn

### DIFF
--- a/backend/startup/nginx.conf
+++ b/backend/startup/nginx.conf
@@ -27,9 +27,16 @@ server {
 
         location / {
                 try_files $uri @gunicorn;
+
         }
 
         location @gunicorn {
+                proxy_set_header Host               $host;
+                proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Host   $host;
+                proxy_set_header X-Forwarded-Server $host;
+                proxy_set_header X-Real-IP          $remote_addr;
+                proxy_redirect off;
                 proxy_pass http://gunicorn;
         }
 


### PR DESCRIPTION
No redirection to https://gunicorn/accounts/profile/